### PR TITLE
Allow numpy 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = { file = "LICENSE" }
 authors = [{ name = "Timothy Nunn", email = "timothy.nunn@ukaea.uk" }]
 requires-python = ">=3.8"
-dependencies = ["numpy>=1.19,<2.0", "cvxpy>=1.5.2"]
+dependencies = ["numpy>=1.19", "cvxpy>=1.5.2"]
 classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Remove restriction for `numpy<2.0` as CVXPY and its dependants now support Numpy 2.0 in their latest releases