### PR TITLE
Possible canonicalisation improvement

### DIFF
--- a/src/pyvmcon/vmcon.py
+++ b/src/pyvmcon/vmcon.py
@@ -279,13 +279,12 @@ def solve_qsp(
     if lbs is not None and ubs is not None:
         equality_index += 1
         constraints.append(lbs <= x + delta <= ubs)
-    else:
-        if lbs is not None:
-            equality_index += 1
-            constraints.append(x + delta >= lbs)
-        if ubs is not None:
-            equality_index += 1
-            constraints.append(x + delta <= ubs)
+    elif lbs is not None:  # and ubs is None
+        equality_index += 1
+        constraints.append(x + delta >= lbs)
+    elif ubs is not None:  # and lbs is None
+        equality_index += 1
+        constraints.append(x + delta <= ubs)
     if problem.has_equality:
         constraints.append((result.deq @ delta) + result.eq == 0)
 

--- a/src/pyvmcon/vmcon.py
+++ b/src/pyvmcon/vmcon.py
@@ -276,12 +276,16 @@ def solve_qsp(
     if problem.has_inequality:
         equality_index += 1
         constraints.append((result.die @ delta) + result.ie >= 0)
-    if lbs is not None:
+    if lbs is not None and ubs is not None:
         equality_index += 1
-        constraints.append(x + delta >= lbs)
-    if ubs is not None:
-        equality_index += 1
-        constraints.append(x + delta <= ubs)
+        constraints.append(lbs <= x + delta <= ubs)
+    else:
+        if lbs is not None:
+            equality_index += 1
+            constraints.append(x + delta >= lbs)
+        if ubs is not None:
+            equality_index += 1
+            constraints.append(x + delta <= ubs)
     if problem.has_equality:
         constraints.append((result.deq @ delta) + result.eq == 0)
 


### PR DESCRIPTION
Final one (I think).

From what I can tell looking at how cvxpy is transforming this into a QSP (at least with the default OSQP), then the present formulation produces an unnecessarily large A matrix in the case where lower and upper bounds are present (additional n dimensions).

This is because the default OSQP solver takes the QP with constraints of the form l [n]<= A[m +n, n]x <= u [n], and with the present approach, the bounds will always get transformed into {-infinity [n], -infinity [n]} <= A[m + 2n, n]x <= {-l [n], u [n]}. Where the last 2n rows of A are the negative and positive identity matrices. Honestly, with sparse matrices its hard to tell if what I am proposing here is "better", but it feels wrong to have bigger matrices when smaller ones will do.