### PR TITLE
Correct BFGS update

### DIFF
--- a/docs/source/vmcon.rst
+++ b/docs/source/vmcon.rst
@@ -164,7 +164,7 @@ The definition of :math:`\vec{\eta}` ensures :math:`\mathbf{B}` remains positive
 We can then perform the BFGS update:
 
 .. math::
-    \mathbf{B_{NEW}} = \mathbf{B} - \frac{\mathbf{B}\vec{\xi}\vec{\xi}^T\mathbf{B}}{\vec{\xi}^T\mathbf{B}\vec{\xi}} + \frac{ \vec{\eta} \vec{\eta}^T}{\vec{\xi}^T\vec{\eta}}
+    \mathbf{B_{NEW}} = \mathbf{B} - \frac{\mathbf{B}\vec{\xi}\vec{\xi}^T\mathbf{B}^T}{\vec{\xi}^T\mathbf{B}\vec{\xi}} + \frac{ \vec{\eta} \vec{\eta}^T}{\vec{\xi}^T\vec{\eta}}
 
 
 The VMCON Algorithm

--- a/src/pyvmcon/vmcon.py
+++ b/src/pyvmcon/vmcon.py
@@ -544,7 +544,7 @@ def calculate_new_B(
 
     # eqn 8
     B_ksi = B @ ksi
-    B += (gamma @ gamma.T) / (ksi.T @ gamma) - ((B_ksi @ ksi.T @ B) / (ksi.T @ B_ksi))
+    B += (gamma @ gamma.T) / (ksi.T @ gamma) - ((B_ksi @ ksi.T @ B.T) / (ksi.T @ B_ksi))
 
     return B
 


### PR DESCRIPTION
I believe that the BFGS update of the Lagrangian function Hessian in PyVMCON is incorrect. If the revision of the `B` matrix were incorrect, this could explain the "Workspace allocation error" being observed in https://github.com/ukaea/PROCESS/pull/3619 (which was happening because `B` was not positive definite and hence the quadratic programming problem failed because it was non-convex, the error would now have a different message because of #21). 


## Crane report
The [Crane report](https://www.osti.gov/servlets/purl/5206574) states the update of the `B` matrix occurs as follows:
![image](https://github.com/user-attachments/assets/0ce96d47-b89a-4af3-b196-120373853b12)

It should be noted there is a typo in the second term that was identified during PyVMCON's development and it should read $\frac{\gamma\gamma^T}{\xi^T\gamma}$. (In some other places the denominator is $\gamma^T\xi$ but that does not change the result.)

## Powell
[Powell's paper](https://link.springer.com/chapter/10.1007/BFb0067703) agrees with the Crane report (as the Crane report is a summary of Powell's paper) except for the second term is correct.

![image](https://github.com/user-attachments/assets/8b68eb02-b1cd-41a2-8395-de3610b8024b)

## BFGS Update
The [BFGS wiki](https://en.wikipedia.org/wiki/Broyden%E2%80%93Fletcher%E2%80%93Goldfarb%E2%80%93Shanno_algorithm) states that the update occurs as follows:
<img width="365" alt="image" src="https://github.com/user-attachments/assets/15ad9fa3-01fa-4bb8-90cd-a02014b9a467" />

Note that this disagrees with both Powell's paper and the Crane report in that the second terms denominator (the first term in the other two papers) reads $B\xi\xi^TB^T$: the final `B` is transposed.


When I update PyVMCON to reflect this, none of the unit tests fail but it does allow the skipped PROCESS file to converge (albeit after 177 iterations).




