### PR TITLE
Stop B becoming unsymmetric due to numerical rounding error

### DIFF
--- a/src/pyvmcon/vmcon.py
+++ b/src/pyvmcon/vmcon.py
@@ -513,9 +513,20 @@ def _revise_B(current_B: MatrixType, ksi: VectorType, gamma: VectorType) -> Matr
 
     Implements Equation 8 of the Crane report.
     """
+    # numerator of the second term
+    term2a = current_B @ np.outer(ksi, ksi) @ current_B
+
+    # term2a will be ever so slightly non-symmetric despite the fact
+    # Bxx^TB is mathematically guaranteed to be symmetric when
+    # B is a real matrix and x is a real vector.
+    # This is because of slight numerical rounding error.
+    # To ensure this error does not accumulate over time and become a problem,
+    # we 'symmetrise' the term by meeting in the middle of the absolute error.
+    term2a = (term2a + term2a.T) / 2.0
+
     return (
         current_B
-        - ((current_B @ np.outer(ksi, ksi) @ current_B) / (ksi.T @ current_B @ ksi))
+        - (term2a / (ksi.T @ current_B @ ksi).item())
         + (np.outer(gamma, gamma) / (ksi.T @ gamma))
     )
 

--- a/tests/test_vmcon.py
+++ b/tests/test_vmcon.py
@@ -59,7 +59,7 @@ def test_revise_B(test_asset):
     new_B = _revise_B(test_asset.B, test_asset.ksi, test_asset.eta)
 
     # check symmetric
-    np.testing.assert_array_almost_equal(new_B, new_B.T, decimal=14)
+    np.testing.assert_array_equal(new_B, new_B.T)
 
     # check our revision agrees with NEA version of VMCON
     np.testing.assert_array_almost_equal(new_B, test_asset.expected_return, decimal=14)


### PR DESCRIPTION
The $B$ matrix was becoming un-symmetric after the first time it was revised. The source of the error was one of the terms in the BFGS revision formula (Equation 8 of the [Crane Report](https://cds.cern.ch/record/125407/files/CM-P00068640.pdf)):

$$
B\xi\xi^TB
$$

which should be symmetric given $B$ is a real matrix and $\xi$ is a real vector. However, the matrix is slightly asymmetric due to numerical rounding error. If this error accumulates too much, it will cause the quadratic programming problem solver to crash.

When evaluating the maximum absolute error over an optimisation run with PyVMCON, the follow graph is produced showing that a) there is a slight asymmetry and b) the error generally accumulates over iterations:
<img width="1412" height="450" alt="image" src="https://github.com/user-attachments/assets/93bd4b6d-e80b-45c7-b8b9-02e702036c38" />

The calculation of the maximum absolute error is as follows
```python
np.abs(B - B.T).max()
```

I have fixed this by averaging element-wise averaging the matrix with its transpose-essentially meeting in the middle of the error and making $B$ perfectly symmetric. 

This is verified by changing the test to raise an exception if there is any difference between $B$ and its transpose (reducing the absolute tolerance to 0).